### PR TITLE
Carry on normalizing getSimInfo methods

### DIFF
--- a/src/telecoopcommon/operator.py
+++ b/src/telecoopcommon/operator.py
@@ -187,6 +187,7 @@ class PhenixConnector:
         result.update(
             {
                 "operatorRef": responseLine["numAbo"],
+                "rio": responseLine["rio"],
                 "international": None,
                 "sva": None,
                 "wha": None,


### PR DESCRIPTION
* Phenix : make second call to get line information (with numAbo)
* Bazile : rename clientCode into operatorRef